### PR TITLE
sort comments by id by default

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,4 @@
 class Comment < ApplicationRecord
+  default_scope {order(:id)}
   belongs_to :image
 end


### PR DESCRIPTION
some students where surprised/confused by the comments coming back not in chronological order. while they could sort them client-side, I think it's better if we sort by id over here to avoid confusion and extra work that's not part of the instructions in the code challenge